### PR TITLE
Disable printscreen key

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -99,3 +99,9 @@ jobs:
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml
           ${{ github.workspace }}/**/hs_err_pid*.log
+    - name: Upload screenshots
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: screenshots
+        path: tests/org.eclipse.swt.tests.win32/screenshots

--- a/binaries/pom.xml
+++ b/binaries/pom.xml
@@ -32,13 +32,13 @@
 	</properties>
 
 	<modules>
-		<module>org.eclipse.swt.cocoa.macosx.x86_64</module>
+		<!--<module>org.eclipse.swt.cocoa.macosx.x86_64</module>
 		<module>org.eclipse.swt.cocoa.macosx.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.aarch64</module>
 		<module>org.eclipse.swt.gtk.linux.ppc64le</module>
 		<module>org.eclipse.swt.gtk.linux.riscv64</module>
 		<module>org.eclipse.swt.gtk.linux.x86_64</module>
-		<module>org.eclipse.swt.win32.win32.aarch64</module>
+		<module>org.eclipse.swt.win32.win32.aarch64</module>-->
 		<module>org.eclipse.swt.win32.win32.x86_64</module>
 	</modules>
 

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Canvas.java
@@ -260,14 +260,15 @@ long gtk_focus_out_event (long widget, long event) {
 }
 
 @Override
-void gtk4_focus_window_event(long handle, long event) {
-	if(event == SWT.FocusIn) {
-		gtk_focus_in_event (handle, event);
-		if (caret != null) caret.setFocus ();
-	} else {
-		gtk_focus_out_event(handle, event);
-		if (caret != null) caret.killFocus();
-	}
+void gtk4_focus_enter_event(long handle, long event) {
+	super.gtk4_focus_enter_event (handle, event);
+	if (caret != null) caret.setFocus ();
+}
+
+@Override
+void gtk4_focus_leave_event(long handle, long event) {
+	super.gtk4_focus_leave_event (handle, event);
+	if (caret != null) caret.setFocus ();
 }
 
 @Override

--- a/pom.xml
+++ b/pom.xml
@@ -183,15 +183,15 @@
 
 
   <modules>
-    <module>bundles</module>
-    <module>binaries</module>
+    <module>bundles/org.eclipse.swt</module>
+    <module>binaries/org.eclipse.swt.win32.win32.x86_64</module>
     <module>local-build/org.eclipse.swt.fragments.localbuild</module>
-    <module>examples/org.eclipse.swt.examples</module>
+    <!--<module>examples/org.eclipse.swt.examples</module>
     <module>examples/org.eclipse.swt.examples.browser.demos</module>
     <module>examples/org.eclipse.swt.examples.launcher</module>
     <module>examples/org.eclipse.swt.examples.ole.win32</module>
-    <module>examples/org.eclipse.swt.examples.views</module>
-    <module>tests/org.eclipse.swt.tests</module>
-    <module>features/org.eclipse.swt.tools.feature</module>
+    <module>examples/org.eclipse.swt.examples.views</module>-->
+    <module>tests/org.eclipse.swt.tests.win32</module>
+    <!--<module>features/org.eclipse.swt.tools.feature</module>-->
   </modules>
 </project>

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/KeyboardLayoutTest.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/KeyboardLayoutTest.java
@@ -15,9 +15,16 @@ package org.eclipse.swt.tests.win32;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.internal.win32.INPUT;
 import org.eclipse.swt.internal.win32.KEYBDINPUT;
 import org.eclipse.swt.internal.win32.OS;
@@ -221,9 +228,21 @@ public class KeyboardLayoutTest {
 	};
 
 	@BeforeEach
-	public void setUp(TestInfo testInfo) {
+	public void setUp(TestInfo testInfo) throws IOException {
 		this.testName = testInfo.getDisplayName();
 		display = new Display();
+		GC gc = new GC(display);
+		Image image = new Image(display, display.getBounds().width, display.getBounds().height);
+		gc.copyArea(image, 0, 0);
+		ImageLoader loader = new ImageLoader();
+		loader.data = new ImageData[]  {image.getImageData()  };
+		File folder = new File("screenshots");
+		if (!folder.exists()) {
+			Files.createDirectory(folder.toPath());
+		}
+		String filePath = folder.getAbsolutePath();
+		loader.save(filePath + "/" + testName + ".png", SWT.IMAGE_PNG);
+
 		shell = new Shell();
 
 		Listener listener = event -> {

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
@@ -234,7 +234,7 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 			new KeyDescription(UsScan.F8,     SWT.F8,          '\0',    '\0'   ),
 			new KeyDescription(UsScan.F9,     SWT.F9,          '\0',    '\0'   ),
 			new KeyDescription(UsScan.F10,    SWT.F10,         '\0',    '\0'   ),
-			new KeyDescription(UsScan.PrtScr, SWT.PRINT_SCREEN,'\0',    '\0'   ),
+			// new KeyDescription(UsScan.PrtScr, SWT.PRINT_SCREEN,'\0',    '\0'   ),
 			new KeyDescription(UsScan.Oem102, '\\',            '\\',    '|'    ),
 			new KeyDescription(UsScan.F11,    SWT.F11,         '\0',    '\0'   ),
 			new KeyDescription(UsScan.F12,    SWT.F12,         '\0',    '\0'   ),
@@ -290,12 +290,12 @@ public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 					if (testKey.scanCode == UsScan.PrtScr) {
 						// For some reason, PrintScreen only produces SWT.KeyUp event.
 						// Maybe because Windows handles WM_KEYDOWN to copy screen to clipboard?
-						String testName = getKeyName(state, testKey.scanCode);
-						expectKeyEvents(
-							testName,
-							() -> emulateScanCode(state, testKey.scanCode),
-							expectKeyUp(state, expectedChar, 0, testKey.keyCode)
-						);
+						// String testName = getKeyName(state, testKey.scanCode);
+						// expectKeyEvents(
+						// 	testName,
+						// 	() -> emulateScanCode(state, testKey.scanCode),
+						// 	expectKeyUp(state, expectedChar, 0, testKey.keyCode)
+						// );
 						continue;
 					}
 

--- a/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
+++ b/tests/org.eclipse.swt.tests.win32/JUnit Tests/org/eclipse/swt/tests/win32/Test_org_eclipse_swt_events_KeyEvent.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.internal.win32.OS;
 import org.eclipse.swt.widgets.Event;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Automated Test Suite for class org.eclipse.swt.events.KeyEvent
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
  * @see org.eclipse.swt.events.KeyEvent
  */
 @SuppressWarnings("restriction")
-@DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true", disabledReason = "Windows Server 2025 incompatibility: https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516")
 public class Test_org_eclipse_swt_events_KeyEvent extends KeyboardLayoutTest {
 	// Windows layouts suitable for 'LoadKeyboardLayout()', obtained from 'GetKeyboardLayoutName()'
 	static char[] LAYOUT_BENGALI        = "00020445\0".toCharArray();


### PR DESCRIPTION
Following on from https://github.com/eclipse-platform/eclipse.platform.swt/issues/2516#issuecomment-3362638228 I try disabling issuing print screen.

But real fix is probably updating isSystemHotkey to detect the additional keys that are problematic.