### PR TITLE
Compare RGB values when comparing image datas with palette data

### DIFF
--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/graphics/ImageDataTestHelper.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/graphics/ImageDataTestHelper.java
@@ -223,7 +223,9 @@ public class ImageDataTestHelper {
 				.thenComparing((ImageData firstData, ImageData secondData) -> {
 					for (int x = 0; x < firstData.width; x++) {
 						for (int y = 0; y < firstData.height; y++) {
-							if (firstData.getPixel(x, y) != secondData.getPixel(x, y)) {
+							RGB first = firstData.palette.getRGB(firstData.getPixel(x, y));
+							RGB second = secondData.palette.getRGB(secondData.getPixel(x, y));
+							if (!first.equals(second)) {
 								return -1;
 							}
 							if (firstData.getAlpha(x, y) != secondData.getAlpha(x, y)) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1081,7 +1081,6 @@ public void test_imageDataIsCached() {
 
 @Test
 public void test_imageDataSameViaDifferentProviders() {
-	assumeFalse(SwtTestUtil.isCocoa, "Cocoa generates inconsistent image data");
 	String imagePath = getPath("collapseall.png");
 	ImageFileNameProvider imageFileNameProvider = zoom -> {
 		return (zoom == 100) ? imagePath : null;
@@ -1107,7 +1106,6 @@ public void test_imageDataSameViaDifferentProviders() {
 
 @Test
 public void test_imageDataSameViaProviderAndSimpleData() {
-	assumeFalse(SwtTestUtil.isCocoa, "Cocoa generates inconsistent image data");
 	String imagePath = getPath("collapseall.png");
 	ImageFileNameProvider imageFileNameProvider = __ -> {
 		return imagePath;


### PR DESCRIPTION
For image datas without palette data (direct palettes) the code before worked ok because the getPixel's returned value was the direct color. But for palette images, the getPixel returns the index.

When an index is used, you need to call getRGB to get the real data value.

Part of https://github.com/eclipse-platform/eclipse.platform.swt/issues/2126